### PR TITLE
Fixed #1 セッションを使うように修正

### DIFF
--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -24,10 +24,9 @@ module Devise
         #
         # Recreates a resource from session data
         #
-        def serialize_from_session(id)
-          resource = self.new
-          resource.id = id
-          resource
+        def serialize_from_session(key, id_token)
+          resource = to_adapter.get(key)
+          resource if resource && firebase_verification(id_token)
         end
 
         #
@@ -37,7 +36,7 @@ module Devise
         # You might want to include some authentication data
         #
         def serialize_into_session(record)
-          [record.id]
+          [record.to_key, record.send(Fireauth.token_key)
         end
 
         def from_firebase(auth_hash)

--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -25,8 +25,10 @@ module Devise
         # Recreates a resource from session data
         #
         def serialize_from_session(key, id_token)
+          auth_hash = firebase_verification(id_token)
+          return nil if auth_hash.empty?
           resource = to_adapter.get(key)
-          resource if resource && firebase_verification(id_token)
+          resource if resource
         end
 
         #

--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -25,6 +25,7 @@ module Devise
         # Recreates a resource from session data
         #
         def serialize_from_session(key, id_token)
+          p key
           puts id_token
           auth_hash = firebase_verification(id_token)
           return nil if auth_hash.empty?
@@ -39,6 +40,7 @@ module Devise
         # You might want to include some authentication data
         #
         def serialize_into_session(record)
+          p record
           [record.to_key, record.send(Fireauth.token_key)]
         end
 

--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -25,6 +25,7 @@ module Devise
         # Recreates a resource from session data
         #
         def serialize_from_session(key, id_token)
+          puts id_token
           auth_hash = firebase_verification(id_token)
           return nil if auth_hash.empty?
           resource = to_adapter.get(key)

--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -36,7 +36,7 @@ module Devise
         # You might want to include some authentication data
         #
         def serialize_into_session(record)
-          [record.to_key, record.send(Fireauth.token_key)
+          [record.to_key, record.send(Fireauth.token_key)]
         end
 
         def from_firebase(auth_hash)

--- a/lib/devise/fireauth/models/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/models/firebase_authenticatable.rb
@@ -15,35 +15,6 @@ module Devise
         # Overriden methods from Devise::Models::Authenticatable
         ####################################
 
-        #
-        # This method is called from:
-        # Warden::SessionSerializer in devise
-        #
-        # It takes as many params as elements had the array
-        # returned in serialize_into_session
-        #
-        # Recreates a resource from session data
-        #
-        def serialize_from_session(key, id_token)
-          p key
-          puts id_token
-          auth_hash = firebase_verification(id_token)
-          return nil if auth_hash.empty?
-          resource = to_adapter.get(key)
-          resource if resource
-        end
-
-        #
-        # Here you have to return and array with the data of your resource
-        # that you want to serialize into the session
-        #
-        # You might want to include some authentication data
-        #
-        def serialize_into_session(record)
-          p record
-          [record.to_key, record.send(Fireauth.token_key)]
-        end
-
         def from_firebase(auth_hash)
           raise NotImplementedError,
             "#{self.name} model must implement class method `from_firebase'"

--- a/lib/devise/fireauth/strategies/firebase_authenticatable.rb
+++ b/lib/devise/fireauth/strategies/firebase_authenticatable.rb
@@ -7,10 +7,6 @@ module Devise
         !token.nil?
       end
 
-      # Don't use Session
-      def store?
-        false
-      end
       #
       # For an example check : https://github.com/plataformatec/devise/blob/master/lib/devise/strategies/database_authenticatable.rb
       #


### PR DESCRIPTION
# 目的
Fixed #1 

# 方針
viewがサーバーサイドのため、セッションを使うように改修

## 参考
https://github.com/yeuem1vannam/devise-fireauth/pull/9/files
[Firebase で普通の Rails アプリにログイン - Diary](https://diary.ssig33.com/posts/535/)

---

# Devise v5 対応

## 概要
Devise v5の破壊的変更を調査し、gemspecのバージョン制約を更新。

## 変更内容（`devise-fireauth.gemspec`）

| 項目 | 変更前 | 変更後 |
|---|---|---|
| devise | `~> 4.0` | `>= 4.0, < 6.0` |
| activesupport | `>= 4` | `>= 7.0` |
| required_ruby_version | 未指定 | `>= 2.7` |

## 調査結果

Devise v5で削除されたAPI（`devise_error_messages!`、`Devise::TestHelpers`、`sign_in`の`:bypass`オプション等）はいずれもこのgemでは**未使用**。

使用中のAPI（`Devise::Strategies::Authenticatable`継承、`Devise.warden`ブロック、`Devise.add_module`、`mapping.to`、`validate`/`success!`/`fail!`）はすべて**v5で健在**。

### 残対応
- `Gemfile`の`rails`バージョンを `~> 7.0` 以上に更新（テスト実行用）